### PR TITLE
fix: 当shell串口为堵塞读取时会始终堵塞在 shell key check 的问题

### DIFF
--- a/src/qboot.c
+++ b/src/qboot.c
@@ -1036,26 +1036,25 @@ static bool qbt_shell_init(const char *shell_dev_name)
     return(true);
 }
 
+
 static bool qbt_shell_key_check(void)
 {
+    bool ret = false;
     char ch;
-    rt_tick_t tick_start = rt_tick_get();
     rt_tick_t tmo = rt_tick_from_millisecond(QBOOT_SHELL_KEY_CHK_TMO * 1000);
 
-    while(rt_tick_get() - tick_start < tmo)
+    if ( rt_sem_take(qbt_shell_sem, tmo) == RT_EOK)
     {
         if (rt_device_read(qbt_shell_dev, -1, &ch, 1) > 0)
         {    
             if (ch == 0x0d)
             {
-                return(true);
+                ret = true;
             }
-            continue;
         }
-        rt_sem_take(qbt_shell_sem, 100);
     }
     
-    return(false);
+    return ret;
 }
 
 static bool qbt_startup_shell(bool wait_press_key)


### PR DESCRIPTION
当 shell 串口为阻塞式读取时，先 read 会导致一直阻塞等待数据输入，不能达到超时退出
修改为获取 shell 串口接收数据信号量后进行 read