### PR TITLE
fix:[shell]重复创建2个同名信号量 && feat:[stm32]使得不需要手动定义宏既可使用

### DIFF
--- a/src/qboot.c
+++ b/src/qboot.c
@@ -20,8 +20,10 @@
 #include <qboot_fastlz.h>
 #include <qboot_quicklz.h>
 #include <string.h>
-
+#ifdef QBOOT_USING_SHELL
 #include "shell.h"
+#endif
+
 #include "crc32.h"
 
 #ifdef QBOOT_USING_STATUS_LED
@@ -971,6 +973,20 @@ static void qbt_close_sys_shell(void)
     else
     {
         rt_thread_delete(thread);
+    }
+
+    rt_sem_t sem = (rt_sem_t)rt_object_find(FINSH_SEM_NAME, RT_Object_Class_Semaphore);
+    if (sem == NULL)
+    {
+        return;
+    }
+    if (rt_object_is_systemobject((rt_object_t)sem))
+    {
+        rt_sem_detach(sem);
+    }
+    else
+    {
+        rt_sem_delete(sem);
     }
 }
 

--- a/src/qboot_stm32.c
+++ b/src/qboot_stm32.c
@@ -7,10 +7,10 @@
  */
 
 #include <board.h>
-
-#ifdef CHIP_FAMILY_STM32
-
 #include <rtthread.h>
+
+#if defined (CHIP_FAMILY_STM32) || defined (SOC_FAMILY_STM32)
+
 #include <rtdevice.h>
 #include <qboot.h>
 


### PR DESCRIPTION
- qboot中开启shell后.list sem 会打印两个同名信号量shrx,进行修复
- stm32.c无法自动构建,需要手动创建宏.修改后使用rtt可以自动构建